### PR TITLE
Adjust linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -Dclippy::pedantic -Aclippy::similar_names
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/src/handler/ts6.rs
+++ b/src/handler/ts6.rs
@@ -89,7 +89,7 @@ impl TS6Handler {
         Outcome::Empty
     }
 
-    fn handle_line_sid(network: &mut Network, sid: &str, line: &Line) -> Outcome {
+    fn handle_line_sid(network: &mut Network, src_sid: &str, line: &Line) -> Outcome {
         match line.command.as_slice() {
             b"SID" => {
                 network.add_server(Server {
@@ -123,7 +123,7 @@ impl TS6Handler {
                 };
                 let host = line.args[5].to_string();
 
-                let server = network.get_server_mut(sid);
+                let server = network.get_server_mut(src_sid);
                 let mut user = User::new(nickname, username, realname, account, ip, rdns, host);
 
                 for (mode, _) in modes_from(&line.args[3]) {
@@ -156,7 +156,7 @@ impl TS6Handler {
             b"ENCAP" => {
                 return TS6Handler::handle_line_encap(
                     network,
-                    sid,
+                    src_sid,
                     &line.args[0],
                     &line.args[1],
                     &line.args[2..],
@@ -205,25 +205,25 @@ impl TS6Handler {
         Outcome::Empty
     }
 
-    fn handle_line_uid(network: &mut Network, uid: &str, line: &Line) -> Outcome {
+    fn handle_line_uid(network: &mut Network, src_uid: &str, line: &Line) -> Outcome {
         match line.command.as_slice() {
             //:420AAAABC QUIT :Quit: Reconnecting
             b"QUIT" => {
-                let sid = &uid[..3];
+                let sid = &src_uid[..3];
                 let server = network.get_server_mut(sid);
-                server.del_user(uid);
+                server.del_user(src_uid);
             }
             //:420AAAABC AWAY :afk
             b"AWAY" => {
-                let sid = &uid[..3];
+                let sid = &src_uid[..3];
                 let server = network.get_server_mut(sid);
-                server.get_user_mut(uid).away = line.args.first().map(ToString::to_string);
+                server.get_user_mut(src_uid).away = line.args.first().map(ToString::to_string);
             }
             //:420AAAABC OPER jess admin
             b"OPER" => {
-                let sid = &uid[..3];
+                let sid = &src_uid[..3];
                 let server = network.get_server_mut(sid);
-                server.get_user_mut(uid).oper = Some(line.args[0].to_string());
+                server.get_user_mut(src_uid).oper = Some(line.args[0].to_string());
             }
             //:420AAAABG MODE 420AAAABG :+p-z
             b"MODE" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,15 @@
+#![deny(clippy::pedantic)]
+#![deny(clippy::dbg_macro)]
+#![deny(clippy::debug_assert_with_mut_call)]
+#![deny(clippy::equatable_if_let)]
+#![deny(clippy::if_then_some_else_none)]
+#![deny(clippy::same_name_method)]
+#![deny(clippy::try_err)]
+#![deny(clippy::undocumented_unsafe_blocks)]
+#![warn(clippy::cognitive_complexity)]
+#![warn(clippy::shadow_unrelated)]
+#![allow(clippy::similar_names)]
+
 mod ban;
 mod channel;
 mod handler;

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,9 +111,9 @@ fn main() {
         };
         println!("< {}", printable);
 
-        if let Outcome::Response(lines) = handled {
-            for line in lines {
-                send(&socket, &line);
+        if let Outcome::Response(resps) = handled {
+            for resp in resps {
+                send(&socket, &resp);
             }
         }
 


### PR DESCRIPTION
This branch:
* Moves where lints are specified into `main.rs` (from clippy arguments in `ci.yml`).
* Adds a fair number of new lints, trying to avoid being overly restrictive while still covering some likely spots for potential improvement.
* Corrects some warnings thrown by one of the new lints.

The big addition that resulted in new warnings is `shadow_unrelated`, which detects shadowing variable bindings that do NOT use the variable they are shadowing in their initialization. ~~I'm not sure if my approach to handling these warnings in `ts6.rs` was ideal; I suspect that the shadowing bindings are, in fact, redundant.~~ EDIT: Upon looking more closely, they are definitely not. Still, to be safe, I instead chose to rename the parameters of the functions containing those bindings.