### PR TITLE
refactor config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,74 +1,56 @@
-use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct Config {
-    pub server_name: String,
-    pub sid: String,
-    pub server_description: String,
+use serde::{Deserialize, Serialize};
+use serde_yaml::from_reader;
 
-    pub uplink_remote_address: String,
-    pub uplink_remote_port: u16,
-    pub uplink_password: String,
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Server {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Uplink {
+    pub host: String,
+    pub port: u16,
+    pub password: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    pub server: Server,
+    pub uplink: Uplink,
 }
 
 #[derive(Debug)]
-pub enum HMConfigError {
-    InvalidSid,
-    InvalidServerName,
+pub enum Error {
     IoError(std::io::Error),
     YamlParseError(String),
 }
 
-impl From<std::io::Error> for HMConfigError {
+impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Self {
         Self::IoError(e)
     }
 }
 
-impl std::fmt::Display for HMConfigError {
+impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         <Self as std::fmt::Debug>::fmt(self, f)
     }
 }
 
-impl std::error::Error for HMConfigError {}
+impl std::error::Error for Error {}
 
 impl Config {
-    pub fn load_from_file(path: impl AsRef<Path>) -> Result<Self, HMConfigError> {
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, Error> {
         let file = File::open(path)?;
         let reader = BufReader::new(file);
 
-        let deserialized_config = match serde_yaml::from_reader::<BufReader<File>, Config>(reader) {
-            Ok(it) => it,
-            Err(err) => {
-                return Err(HMConfigError::YamlParseError(err.to_string()));
-            }
-        };
-        deserialized_config.validate()
-    }
-
-    fn validate(self) -> Result<Self, HMConfigError> {
-        let sid = self.sid.as_bytes();
-
-        if sid.len() != 3
-            || !sid[0].is_ascii_digit()
-            || !(sid[1].is_ascii_uppercase() || sid[1].is_ascii_digit())
-            || !(sid[2].is_ascii_uppercase() || sid[2].is_ascii_digit())
-        {
-            return Err(HMConfigError::InvalidSid);
-        }
-
-        if !self
-            .server_name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '.')
-        {
-            return Err(HMConfigError::InvalidServerName);
-        }
-
-        Ok(self)
+        from_reader::<BufReader<File>, Config>(reader)
+            .map_err(|e| Error::YamlParseError(e.to_string()))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::BufReader;
+use std::io::{BufReader, Error as IoError};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -27,13 +27,14 @@ pub struct Config {
 
 #[derive(Debug)]
 pub enum Error {
-    IoError(std::io::Error),
-    YamlParseError(String),
+    Io(std::io::Error),
+    InvalidYaml(String),
+    InvalidData(String),
 }
 
-impl From<std::io::Error> for Error {
-    fn from(e: std::io::Error) -> Self {
-        Self::IoError(e)
+impl From<IoError> for Error {
+    fn from(e: IoError) -> Self {
+        Self::Io(e)
     }
 }
 
@@ -51,6 +52,6 @@ impl Config {
         let reader = BufReader::new(file);
 
         from_reader::<BufReader<File>, Config>(reader)
-            .map_err(|e| Error::YamlParseError(e.to_string()))
+            .map_err(|e| Error::InvalidYaml(e.to_string()))
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -2,6 +2,7 @@ pub mod ts6;
 
 use std::ops::RangeFrom;
 
+use crate::config::{Config, Error as ConfigError};
 use crate::line::Line;
 use crate::network::{Error as StateError, Network};
 
@@ -21,11 +22,14 @@ pub enum Error {
 }
 
 pub trait Handler {
+    fn validate_config(&self, config: &Config) -> Result<(), ConfigError>;
+
     fn get_burst<'a>(
         &self,
         network: &Network,
         password: &'a str,
     ) -> Result<Vec<String>, &'static str>;
+
     fn handle(&mut self, network: &mut Network, line: Line) -> Result<Outcome, Error>;
 }
 

--- a/src/handler/ts6.rs
+++ b/src/handler/ts6.rs
@@ -22,6 +22,9 @@ mod util;
 
 use std::time::SystemTime;
 
+use regex::Regex;
+
+use crate::config::{Config, Error as ConfigError};
 use crate::handler::{Error, Handler, Outcome};
 use crate::line::Line;
 use crate::network::Network;
@@ -54,11 +57,25 @@ pub struct TS6Handler {
 
 impl TS6Handler {
     pub fn new() -> Self {
-        Self::default()
+        TS6Handler::default()
     }
 }
 
 impl Handler for TS6Handler {
+    fn validate_config(&self, config: &Config) -> Result<(), ConfigError> {
+        //TODO: precompile
+        let regex_sid = Regex::new(r"^[0-9][0-9A-Z]{2}$").unwrap();
+        let regex_name = Regex::new(r"^[0-9a-zA-Z]+\.[0-9a-zA-Z\.]*$").unwrap();
+
+        if !regex_sid.is_match(&config.server.id) {
+            Err(ConfigError::InvalidData("server id".to_string()))
+        } else if !regex_name.is_match(&config.server.name) {
+            Err(ConfigError::InvalidData("server name".to_string()))
+        } else {
+            Ok(())
+        }
+    }
+
     fn get_burst<'a>(
         &self,
         network: &Network,

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,13 +83,16 @@ fn main() {
         }
     };
 
+    let handler = TS6Handler::new();
+    handler.validate_config(&config).expect("invalid config");
+
     let mut haematite = Haematite::new(
         Server::new(
             config.server.id,
             config.server.name,
             config.server.description,
         ),
-        TS6Handler::new(),
+        handler,
     );
 
     let socket =


### PR DESCRIPTION
this aims to do 3 things;

1. minimise code
2. take advantage of complex yaml structures
3. remove post-deserialise validation from `config.rs` as it's protocol-specific

todo:

~~- implement post-deserialise validation in `ts6.rs`~~