### PR TITLE
Translate a error to english

### DIFF
--- a/haematite_s2s/src/ts6/mod.rs
+++ b/haematite_s2s/src/ts6/mod.rs
@@ -77,7 +77,7 @@ impl Handler for TS6Handler {
             format!(
                 "SVINFO 6 6 0 {}",
                 now.duration_since(SystemTime::UNIX_EPOCH)
-                    .map_err(|_e| "GRAN PROBLEMA DE TIEMPO".to_string())?
+                    .map_err(|_e| "BIG TIME ISSUE".to_string())?
                     .as_secs()
             ),
         ])


### PR DESCRIPTION
The error was originally in Spanish and said "big time issue" in caps.